### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   frontend-build:
     name: Frontend Build


### PR DESCRIPTION
Potential fix for [https://github.com/d4rkr0n1n/spring-boot-play/security/code-scanning/2](https://github.com/d4rkr0n1n/spring-boot-play/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only involves building Java projects and does not interact with repository contents or other GitHub features, the `contents: read` permission is sufficient. This change will apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
